### PR TITLE
Handle unicode in error message in a simpler way

### DIFF
--- a/ghc-typelits-extra.cabal
+++ b/ghc-typelits-extra.cabal
@@ -100,12 +100,10 @@ test-suite test-ghc-typelits-extra
                        ghc-typelits-knownnat     >= 0.6,
                        ghc-typelits-natnormalise >= 0.4.1,
                        tasty                     >= 0.10,
-                       tasty-hunit               >= 0.9,
-                       template-haskell          >= 2.11.0.0
+                       tasty-hunit               >= 0.9
   hs-source-dirs:      tests
   default-language:    Haskell2010
   other-extensions:    DataKinds
-                       TemplateHaskell
                        TypeOperators
   if flag(deverror)
     ghc-options:       -O0 -dcore-lint

--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DataKinds, TypeOperators, TypeApplications, TypeFamilies, TemplateHaskell #-}
+{-# LANGUAGE CPP, DataKinds, TypeOperators, TypeApplications, TypeFamilies #-}
 #if __GLASGOW_HASKELL__ >= 805
 {-# LANGUAGE NoStarIsType #-}
 #endif
@@ -12,10 +12,6 @@ module ErrorTests where
 import Data.Proxy
 import GHC.TypeLits
 import GHC.TypeLits.Extra
-
-import GHC.IO.Encoding            (getLocaleEncoding, textEncodingName, utf8)
-import Language.Haskell.TH        (litE, stringL)
-import Language.Haskell.TH.Syntax (runIO)
 
 testFail1 :: Proxy (GCD 6 8) -> Proxy 4
 testFail1 = id
@@ -147,18 +143,10 @@ testFail9Errors =
   ]
 
 testFail10Errors =
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Couldn't match type ‘'False’ with ‘'True’"
-          else litE $ stringL "Couldn't match type 'False with 'True"
-    )]
+  ["Couldn't match type ‘'False’ with ‘'True’"]
 
 testFail11Errors =
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Couldn't match type ‘CLog 2 4 <=? CLog 4 4’ with ‘'True’"
-          else litE $ stringL "Couldn't match type `CLog 2 4 <=? CLog 4 4' with 'True"
-    )]
+  ["Couldn't match type ‘CLog 2 4 <=? CLog 4 4’ with ‘'True’"]
 
 testFail12Errors =
   ["Expected type: Proxy (Div 4 0) -> Proxy 4"
@@ -196,18 +184,10 @@ testFail18Errors =
   ]
 
 testFail19Errors =
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Couldn't match type ‘FLog 3 0’ with ‘CLog 3 0’"
-          else litE $ stringL "Couldn't match type `FLog 3 0' with `CLog 3 0'"
-    )]
+  ["Couldn't match type ‘FLog 3 0’ with ‘CLog 3 0’"]
 
 testFail20Errors =
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Couldn't match type ‘FLog 3 10’ with ‘CLog 3 10’"
-          else litE $ stringL "Couldn't match type `FLog 3 10' with `CLog 3 10'"
-    )]
+  ["Couldn't match type ‘FLog 3 10’ with ‘CLog 3 10’"]
 
 testFail21Errors =
   ["Expected type: Proxy (Min a (a * b)) -> Proxy a"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -346,6 +346,12 @@ throws v xs = do
   case result of
     Right _ -> assertFailure "No exception!"
     Left (TypeError msg) ->
-      if all (`isInfixOf` msg) xs
+      if all (`isInfixOf` (removeProblemChars msg)) $ map removeProblemChars xs
          then return ()
          else assertFailure msg
+
+-- The kind and amount of quotes in GHC error messages changes depending on
+-- whether or not our locale supports unicode.
+-- Remove the problematic characters to enable comparison of errors.
+removeProblemChars = filter (`notElem` problemChars)
+  where problemChars = "‘’`'"


### PR DESCRIPTION
The handling of possible unicode quotes in the error messages is complex and error prone. 
(For example currently testFail23 will fail it's test when your locale has no unicode support.)

To sidestep this issue, I just filter out all the offending quote characters and compare what's left.
 