### PR TITLE
Tell GHC that a <= Max a b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-extra`](http://hackage.haskell.org/package/ghc-typelits-extra) package
 
+# 0.2.5
+* Reduce `a <=? Max a b` to `True`
+
 # 0.2.4 *January 4th 2018*
 * Add support for GHC-8.4.1-alpha1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 0.2.5
 * Reduce `a <=? Max a b` to `True`
+* Reduce `n ~ (Max a b) => a <=? n` to `True`
 
 # 0.2.4 *January 4th 2018*
 * Add support for GHC-8.4.1-alpha1

--- a/ghc-typelits-extra.cabal
+++ b/ghc-typelits-extra.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-extra
-version:             0.2.4
+version:             0.2.5
 synopsis:            Additional type-level operations on GHC.TypeLits.Nat
 description:
   Additional type-level operations on @GHC.TypeLits.Nat@:

--- a/src/GHC/TypeLits/Extra/Solver.hs
+++ b/src/GHC/TypeLits/Extra/Solver.hs
@@ -134,6 +134,8 @@ simplifyExtra eqs = tcPluginTrace "simplifyExtra" (ppr eqs) >> simples [] eqs
         (I i,I j)
           | (i <= j) == b -> simples (((,) <$> evMagic ct <*> pure ct):evs) eqs'
           | otherwise     -> return  (Impossible eq)
+        (p, Max x y)
+          | b && (p == x || p == y) -> simples (((,) <$> evMagic ct <*> pure ct):evs) eqs'
         _ -> simples evs eqs'
 
 

--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -93,6 +93,11 @@ testFail24 _ _ _ = id
 testFail25 :: Proxy x -> Proxy y -> Proxy (x+1 <=? Max x y) -> Proxy True
 testFail25 _ _ = id
 
+-- While n ~ (Max x y) implies x <= n (see test46), the reverse is not true.
+testFail26' :: ((x <=? n) ~ True)  => Proxy x -> Proxy y -> Proxy n -> Proxy ((Max x y)) -> Proxy n
+testFail26' _ _ _ = id
+
+testFail26 = testFail26' (Proxy @4) (Proxy @6) (Proxy @6)
 
 testFail1Errors =
   ["Expected type: Proxy (GCD 6 8) -> Proxy 4"
@@ -223,3 +228,8 @@ testFail24Errors =
 
 testFail25Errors =
   ["Couldn't match type ‘(x + 1) <=? Max x y’ with ‘'True’"]
+
+testFail26Errors =
+  ["Could not deduce: Max x y ~ n"
+  ,"from the context: (x <=? n) ~ 'True"
+  ]

--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -87,6 +87,12 @@ testFail23' _ _ = ()
 testFail23 :: ()
 testFail23 = testFail23' (Proxy @18) (Proxy @3)
 
+testFail24 :: Proxy x -> Proxy y -> Proxy z -> Proxy (z <=? Max x y) -> Proxy True
+testFail24 _ _ _ = id
+
+testFail25 :: Proxy x -> Proxy y -> Proxy (x+1 <=? Max x y) -> Proxy True
+testFail25 _ _ = id
+
 
 testFail1Errors =
   ["Expected type: Proxy (GCD 6 8) -> Proxy 4"
@@ -211,3 +217,9 @@ testFail23Errors =
 #else
   ["Couldn't match type ‘1 <=? Div 18 3’ with ‘'False’"]
 #endif
+
+testFail24Errors =
+  ["Couldn't match type ‘z <=? Max x y’ with ‘'True’"]
+
+testFail25Errors =
+  ["Couldn't match type ‘(x + 1) <=? Max x y’ with ‘'True’"]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -151,6 +151,12 @@ test44 _ _ = id
 test45 :: Proxy x -> Proxy y -> Proxy (y <=? (Max x y)) -> Proxy True
 test45 _ _ = id
 
+test46 :: n ~ (Max x y) => Proxy x -> Proxy y -> Proxy (x <=? n) -> Proxy True
+test46 _ _ = id
+
+test47 :: n ~ (Max x y) => Proxy x -> Proxy y -> Proxy (y <=? n) -> Proxy True
+test47 _ _ = id
+
 main :: IO ()
 main = defaultMain tests
 
@@ -292,6 +298,12 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "forall x y . y <=? Max x y ~ True" $
       show (test45 Proxy Proxy Proxy) @?=
       "Proxy"
+    , testCase "forall x y n . n ~ Max x y => x <=? n ~ True" $
+      show (test46 Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall x y n . n ~ Max x y => y <=? n ~ True" $
+      show (test47 Proxy Proxy Proxy) @?=
+      "Proxy"
     ]
   , testGroup "errors"
     [ testCase "GCD 6 8 /~ 4" $ testFail1 `throws` testFail1Errors
@@ -319,6 +331,7 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "(1 <=? Div 18 6) ~ False" $ testFail23 `throws` testFail23Errors
     , testCase "(z <=? Max x y) /~ True" $ testFail24 `throws` testFail24Errors
     , testCase "(x+1 <=? Max x y) /~ True" $ testFail25 `throws` testFail25Errors
+    , testCase "(x <= n) /=> (Max x y) ~ n" $ testFail26 `throws` testFail26Errors
     ]
   ]
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -145,6 +145,12 @@ test42 _ _ = id
 test43 :: Proxy x -> Proxy y -> Proxy (LCM x y) -> Proxy (LCM y x)
 test43 _ _ = id
 
+test44 :: Proxy x -> Proxy y -> Proxy (x <=? (Max x y)) -> Proxy True
+test44 _ _ = id
+
+test45 :: Proxy x -> Proxy y -> Proxy (y <=? (Max x y)) -> Proxy True
+test45 _ _ = id
+
 main :: IO ()
 main = defaultMain tests
 
@@ -280,6 +286,12 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "forall x y . LCM x y ~ LCM y x" $
       show (test43 Proxy Proxy Proxy) @?=
       "Proxy"
+    , testCase "forall x y . x <=? Max x y ~ True" $
+      show (test44 Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall x y . y <=? Max x y ~ True" $
+      show (test45 Proxy Proxy Proxy) @?=
+      "Proxy"
     ]
   , testGroup "errors"
     [ testCase "GCD 6 8 /~ 4" $ testFail1 `throws` testFail1Errors
@@ -305,6 +317,8 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "Min a (a*b) /~ a" $ testFail21 `throws` testFail21Errors
     , testCase "Max a (a*b) /~ (a*b)" $ testFail22 `throws` testFail22Errors
     , testCase "(1 <=? Div 18 6) ~ False" $ testFail23 `throws` testFail23Errors
+    , testCase "(z <=? Max x y) /~ True" $ testFail24 `throws` testFail24Errors
+    , testCase "(x+1 <=? Max x y) /~ True" $ testFail25 `throws` testFail25Errors
     ]
   ]
 


### PR DESCRIPTION
By telling GHC that a <= Max a b it knows that (Max a b - a) is a valid Nat.

And you can do things like this:
```haskell
-- | Overwrite either the first a of the last b bits.
overwrite :: forall a b. (KnownNat a, KnownNat b)
          => BitVector (Max a b) -> Either (BitVector a) (BitVector b) -> BitVector (Max a b)
overwrite ab (Left a) = a ++# rest
  where (_, rest) = split ab :: (BitVector a,  BitVector (Max a b - a))
overwrite ab (Right b) = rest ++# b
  where (rest, _) = split ab :: (BitVector (Max a b - b), BitVector b)
```