### PR TITLE
Fix type error after `isNatural` change

### DIFF
--- a/src/GHC/TypeLits/Extra/Solver/Operations.hs
+++ b/src/GHC/TypeLits/Extra/Solver/Operations.hs
@@ -111,7 +111,8 @@ mergeMax defs x y =
   let x' = reifyEOP defs x
       y' = reifyEOP defs y
       z  = fst (runWriter (normaliseNat (mkTyConApp typeNatSubTyCon [y',x'])))
-  in  case isNatural z of
+      z' = fst <$> runWriterT (isNatural z)
+  in  case z' of
         Just True  -> y
         Just False -> x
         _ -> Max x y
@@ -121,7 +122,8 @@ mergeMin defs x y =
   let x' = reifyEOP defs x
       y' = reifyEOP defs y
       z  = fst (runWriter (normaliseNat (mkTyConApp typeNatSubTyCon [y',x'])))
-  in  case isNatural z of
+      z' = fst <$> runWriterT (isNatural z)
+  in  case z' of
         Just True  -> x
         Just False -> y
         _ -> Min x y


### PR DESCRIPTION
This fixes a type error after `isNatural` changed in `ghc-typelits-natnormalise`. It is not the prettiest fix (would probably be better to generalise `normaliseNat`  to work for arbitrary transformer monads but that would require a change to `natnormalise` i.e. `normaliseNat :: forall m . Monad m => .. -> WriterT _ m _`).