### PR TITLE
Add `GHC.Magic.noinline` to `gcd` and `lcm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-extra`](http://hackage.haskell.org/package/ghc-typelits-extra) package
 
+# 0.3.2 *January 18th 2020*
+* Fix https://github.com/clash-lang/clash-compiler/issues/1019
+
 # 0.3.1 *August 26th 2019*
 * Reduce `a <=? Max a b` to `True`
 * Reduce `n ~ (Max a b) => a <=? n` to `True`

--- a/ghc-typelits-extra.cabal
+++ b/ghc-typelits-extra.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-extra
-version:             0.3.1
+version:             0.3.2
 synopsis:            Additional type-level operations on GHC.TypeLits.Nat
 description:
   Additional type-level operations on @GHC.TypeLits.Nat@:

--- a/src/GHC/TypeLits/Extra.hs
+++ b/src/GHC/TypeLits/Extra.hs
@@ -83,6 +83,9 @@ import Data.Type.Bool         (If)
 import GHC.Base               (Int#,isTrue#,(==#),(+#))
 import GHC.Integer.Logarithms (integerLogBase#)
 #if MIN_VERSION_ghc(8,2,0)
+import GHC.Magic              (noinline)
+#endif
+#if MIN_VERSION_ghc(8,2,0)
 import qualified GHC.TypeNats as N
 import GHC.Natural
 import GHC.Prim               (int2Word#)
@@ -217,7 +220,11 @@ type family GCD (x :: Nat) (y :: Nat) :: Nat where
   -- Additional equations are provided by the custom solver
 
 instance (KnownNat x, KnownNat y) => KnownNat2 $(nameToSymbol ''GCD) x y where
-  natSing2 = SNatKn (gcd (N.natVal (Proxy @x)) (N.natVal (Proxy @y)))
+  natSing2 = SNatKn (
+#if MIN_VERSION_ghc(8,2,0)
+    noinline
+#endif
+      gcd (N.natVal (Proxy @x)) (N.natVal (Proxy @y)))
 
 -- | Type-level least common multiple (LCM).
 --
@@ -232,4 +239,8 @@ type family LCM (x :: Nat) (y :: Nat) :: Nat where
   -- Additional equations are provided by the custom solver
 
 instance (KnownNat x, KnownNat y) => KnownNat2 $(nameToSymbol ''LCM) x y where
-  natSing2 = SNatKn (lcm (N.natVal (Proxy @x)) (N.natVal (Proxy @y)))
+  natSing2 = SNatKn (
+#if MIN_VERSION_ghc(8,2,0)
+    noinline
+#endif
+      lcm (N.natVal (Proxy @x)) (N.natVal (Proxy @y)))


### PR DESCRIPTION
GHC 8.6+ inlines their definitions, which exposes some of their FFI calls to the Clash compiler, which it cannot evaluate at compile-time.

Fixes https://github.com/clash-lang/clash-compiler/issues/1019