### PR TITLE
Distribute add, mul, and sub  through Max and Min

### DIFF
--- a/src/GHC/TypeLits/Extra/Solver.hs
+++ b/src/GHC/TypeLits/Extra/Solver.hs
@@ -310,7 +310,8 @@ lookupExtraDefs = do
 #if MIN_VERSION_ghc(9,2,0)
     md2 <- lookupModule ordModule basePackage
 #endif
-    ExtraDefs <$> look md "Max"
+    ExtraDefs <$> pure (typeNatTyCons !! 0)
+              <*> look md "Max"
               <*> look md "Min"
 #if MIN_VERSION_ghc(8,4,0)
               <*> pure (typeNatTyCons !! 5)

--- a/src/GHC/TypeLits/Extra/Solver.hs
+++ b/src/GHC/TypeLits/Extra/Solver.hs
@@ -80,7 +80,7 @@ import TcRnTypes  (TcPlugin(..), TcPluginResult (..))
 import Type       (Kind, eqType, mkTyConApp, splitTyConApp_maybe)
 import TyCoRep    (Type (..))
 import TysWiredIn (typeNatKind, promotedTrueDataCon, promotedFalseDataCon)
-import TcTypeNats (typeNatLeqTyCon)
+import TcTypeNats (typeNatLeqTyCon, typeNatMulTyCon, typeNatAddTyCon, typeNatSubTyCon)
 #if MIN_VERSION_ghc(8,4,0)
 import TcTypeNats (typeNatTyCons)
 #else
@@ -310,7 +310,9 @@ lookupExtraDefs = do
 #if MIN_VERSION_ghc(9,2,0)
     md2 <- lookupModule ordModule basePackage
 #endif
-    ExtraDefs <$> pure (typeNatTyCons !! 0)
+    ExtraDefs <$> pure typeNatAddTyCon
+              <*> pure typeNatSubTyCon
+              <*> pure typeNatMulTyCon
               <*> look md "Max"
               <*> look md "Min"
 #if MIN_VERSION_ghc(8,4,0)

--- a/src/GHC/TypeLits/Extra/Solver/Operations.hs
+++ b/src/GHC/TypeLits/Extra/Solver/Operations.hs
@@ -89,7 +89,7 @@ data ExtraOp
   | GCD  ExtraOp ExtraOp
   | LCM  ExtraOp ExtraOp
   | Exp  ExtraOp ExtraOp
-  deriving Eq
+  deriving (Eq, Ord)
 
 instance Outputable ExtraOp where
   ppr (I i)      = integer i
@@ -161,7 +161,10 @@ mergePlus _ (Max a b) y = (Max (Plus a y) (Plus b y), Normalised)
 mergePlus _ x (Max a b) = (Max (Plus x a) (Plus x b), Normalised)
 mergePlus _ (Min a b) y = (Min (Plus a y) (Plus b y), Normalised)
 mergePlus _ x (Min a b) = (Min (Plus x a) (Plus x b), Normalised)
-mergePlus _ x y = (Plus x y, Untouched)
+-- Give a canonical ordering so we can pretend like we have commutativity.
+mergePlus _ x y = (case x <= y of
+                     True -> Plus x y
+                     False-> Plus y x, Untouched)
 
 mergeSub :: ExtraDefs -> ExtraOp -> ExtraOp -> NormaliseResult
 mergeSub _ (Max a b) y = (Max (Sub a y) (Sub b y), Normalised)
@@ -173,7 +176,10 @@ mergeMul _ (Max a b) y = (Max (Mul a y) (Mul b y), Normalised)
 mergeMul _ x (Max a b) = (Max (Mul x a) (Mul x b), Normalised)
 mergeMul _ (Min a b) y = (Min (Mul a y) (Mul b y), Normalised)
 mergeMul _ x (Min a b) = (Min (Mul x a) (Mul x b), Normalised)
-mergeMul _ x y = (Mul x y, Untouched)
+-- Give a canonical ordering so we can pretend like we have commutativity.
+mergeMul _ x y = (case x <= y of
+                    True -> Mul x y
+                    False-> Mul y x, Untouched)
 
 mergeMax :: ExtraDefs -> ExtraOp -> ExtraOp -> NormaliseResult
 mergeMax _ (I 0) y = (y, Normalised)

--- a/src/GHC/TypeLits/Extra/Solver/Unify.hs
+++ b/src/GHC/TypeLits/Extra/Solver/Unify.hs
@@ -69,6 +69,12 @@ normaliseNat defs (TyConApp tc [x,y])
   | tc == plusTyCon defs = mergeNormResWith (\x' y' -> return (mergePlus defs x' y'))
                                             (normaliseNat defs x)
                                             (normaliseNat defs y)
+  | tc == subTyCon defs = mergeNormResWith (\x' y' -> return (mergeSub defs x' y'))
+                                           (normaliseNat defs x)
+                                           (normaliseNat defs y)
+  | tc == mulTyCon defs = mergeNormResWith (\x' y' -> return (mergeMul defs x' y'))
+                                           (normaliseNat defs x)
+                                           (normaliseNat defs y)
   | tc == maxTyCon defs = mergeNormResWith (\x' y' -> return (mergeMax defs x' y'))
                                            (normaliseNat defs x)
                                            (normaliseNat defs y)
@@ -156,6 +162,8 @@ fvOP (I _)      = emptyUniqSet
 fvOP (V v)      = unitUniqSet v
 fvOP (C _)      = emptyUniqSet
 fvOP (Plus x y) = fvOP x `unionUniqSets` fvOP y
+fvOP (Sub x y)  = fvOP x `unionUniqSets` fvOP y
+fvOP (Mul  x y) = fvOP x `unionUniqSets` fvOP y
 fvOP (Max x y)  = fvOP x `unionUniqSets` fvOP y
 fvOP (Min x y)  = fvOP x `unionUniqSets` fvOP y
 fvOP (Div x y)  = fvOP x `unionUniqSets` fvOP y
@@ -174,7 +182,9 @@ containsConstants :: ExtraOp -> Bool
 containsConstants (I _) = False
 containsConstants (V _) = False
 containsConstants (C _) = True
-containsConstants (Plus x y) = containsConstants x || containsConstants y
+containsConstants (Plus _ _) = True
+containsConstants (Sub _ _) = True
+containsConstants (Mul _ _) = True
 containsConstants (Max x y)  = containsConstants x || containsConstants y
 containsConstants (Min x y)  = containsConstants x || containsConstants y
 containsConstants (Div x y)  = containsConstants x || containsConstants y

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -223,6 +223,18 @@ test57
   -> Proxy True
 test57 _ _ = id
 
+test58 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Max x y + n) -> Proxy (Max (x + n) (y + n))
+test58 _ _ _ = id
+
+test59 :: Proxy n -> Proxy x -> Proxy y -> Proxy (n + Max x y) -> Proxy (Max (n + x) (n + y))
+test59 _ _ _ = id
+
+test60 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Min x y + n) -> Proxy (Min (x + n) (y + n))
+test60 _ _ _ = id
+
+test61 :: Proxy n -> Proxy x -> Proxy y -> Proxy (n + Min x y) -> Proxy (Min (n + x) (n + y))
+test61 _ _ _ = id
+
 main :: IO ()
 main = defaultMain tests
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -253,6 +253,9 @@ test66 _ _ _ = id
 test67 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Min x y - n) -> Proxy (Min (x - n) (y - n))
 test67 _ _ _ = id
 
+test68 :: Proxy a -> Proxy b -> Proxy n -> Proxy (Max (a + n) (b + n)) -> Proxy (n + Max a b)
+test68 _ _ _ = id
+
 
 main :: IO ()
 main = defaultMain tests
@@ -428,38 +431,41 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "forall n p . n <= Max (n + p) p" $
       show (test56 Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . n + 1 <= Max (n + p + 1) p" $
+    , testCase "forall a b n. n + 1 <= Max (n + p + 1) p" $
       show (test57 Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . Max a b + n = Max (a + n) (b + n)" $
+    , testCase "forall a b n. Max a b + n = Max (a + n) (b + n)" $
       show (test58 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . n + Max a b = Max (n + a) (n + b)" $
+    , testCase "forall a b n. n + Max a b = Max (n + a) (n + b)" $
       show (test59 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . Min a b + n = Min (a + n) (b + n)" $
+    , testCase "forall a b n. Min a b + n = Min (a + n) (b + n)" $
       show (test60 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . n + Min a b = Min (n + a) (n + b)" $
+    , testCase "forall a b n. n + Min a b = Min (n + a) (n + b)" $
       show (test61 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . Max a b * n = Max (a * n) (b * n)" $
+    , testCase "forall a b n. Max a b * n = Max (a * n) (b * n)" $
       show (test62 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . n * Max a b = Max (n * a) (n * b)" $
+    , testCase "forall a b n. n * Max a b = Max (n * a) (n * b)" $
       show (test63 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . Min a b * n = Min (a * n) (b * n)" $
+    , testCase "forall a b n. Min a b * n = Min (a * n) (b * n)" $
       show (test64 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . n * Min a b = Min (n * a) (n * b)" $
+    , testCase "forall a b n. n * Min a b = Min (n * a) (n * b)" $
       show (test65 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . Max a b - n = Max (a - n) (b - n)" $
+    , testCase "forall a b n. Max a b - n = Max (a - n) (b - n)" $
       show (test66 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
-    , testCase "forall n p . Min a b - n = Min (a - n) (b - n)" $
+    , testCase "forall a b n. Min a b - n = Min (a - n) (b - n)" $
       show (test67 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall a b n. Max (a + n) (b + n) = n + Max a b" $
+      show (test68 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
     ]
   , testGroup "errors"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -235,6 +235,25 @@ test60 _ _ _ = id
 test61 :: Proxy n -> Proxy x -> Proxy y -> Proxy (n + Min x y) -> Proxy (Min (n + x) (n + y))
 test61 _ _ _ = id
 
+test62 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Max x y * n) -> Proxy (Max (x * n) (y * n))
+test62 _ _ _ = id
+
+test63 :: Proxy n -> Proxy x -> Proxy y -> Proxy (n * Max x y) -> Proxy (Max (n * x) (n * y))
+test63 _ _ _ = id
+
+test64 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Min x y * n) -> Proxy (Min (x * n) (y * n))
+test64 _ _ _ = id
+
+test65 :: Proxy n -> Proxy x -> Proxy y -> Proxy (n * Min x y) -> Proxy (Min (n * x) (n * y))
+test65 _ _ _ = id
+
+test66 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Max x y - n) -> Proxy (Max (x - n) (y - n))
+test66 _ _ _ = id
+
+test67 :: Proxy n -> Proxy x -> Proxy y -> Proxy (Min x y - n) -> Proxy (Min (x - n) (y - n))
+test67 _ _ _ = id
+
+
 main :: IO ()
 main = defaultMain tests
 
@@ -411,6 +430,36 @@ tests = testGroup "ghc-typelits-natnormalise"
       "Proxy"
     , testCase "forall n p . n + 1 <= Max (n + p + 1) p" $
       show (test57 Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . Max a b + n = Max (a + n) (b + n)" $
+      show (test58 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . n + Max a b = Max (n + a) (n + b)" $
+      show (test59 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . Min a b + n = Min (a + n) (b + n)" $
+      show (test60 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . n + Min a b = Min (n + a) (n + b)" $
+      show (test61 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . Max a b * n = Max (a * n) (b * n)" $
+      show (test62 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . n * Max a b = Max (n * a) (n * b)" $
+      show (test63 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . Min a b * n = Min (a * n) (b * n)" $
+      show (test64 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . n * Min a b = Min (n * a) (n * b)" $
+      show (test65 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . Max a b - n = Max (a - n) (b - n)" $
+      show (test66 Proxy Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "forall n p . Min a b - n = Min (a - n) (b - n)" $
+      show (test67 Proxy Proxy Proxy Proxy) @?=
       "Proxy"
     ]
   , testGroup "errors"


### PR DESCRIPTION
This PR rewrites terms of the form `Max a b + n` into `Max (a + n) (b + n)`, also for `Min`, and for `*` and `-` as well. It has commutative rules for plus and mul as well.

Fixes #35 