### PR TITLE
Parse `Assert`-based constraints in GHC 9.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-extra`](http://hackage.haskell.org/package/ghc-typelits-extra) package
 
+# 0.4.7
+* Fix Plugin silently fails when normalizing <= in GHC 9.4+ [#50](https://github.com/clash-lang/ghc-typelits-extra/issues/50)
+
 # 0.4.6 *October 10th 2023*
 * Support for GHC-9.8.1
 

--- a/ghc-typelits-extra.cabal
+++ b/ghc-typelits-extra.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-extra
-version:             0.4.6
+version:             0.4.7
 synopsis:            Additional type-level operations on GHC.TypeLits.Nat
 description:
   Additional type-level operations on @GHC.TypeLits.Nat@:

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -223,6 +223,17 @@ test57
   -> Proxy True
 test57 _ _ = id
 
+test58a
+  :: 1 <= n
+  => Proxy n
+  -> Proxy n
+test58a = id
+
+test58b
+  :: Proxy (Max (n+2) 1)
+  -> Proxy (Max (n+2) 1)
+test58b = test58a
+
 main :: IO ()
 main = defaultMain tests
 


### PR DESCRIPTION
So we can create new wanted constraints from them. Before, we would only recognise `~`-based constraints. We need to parse `Assert`-based constraints because it is used to implement `<=`.

Also, we no longer silently fails when it's unexpected constraint.