### PR TITLE
Fix lookup `Div` and `Mod` GHC >= 9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+dist-newstyle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-extra`](http://hackage.haskell.org/package/ghc-typelits-extra) package
 
+# Unreleased
+* Fix faulty lookup for `Mod` and `Div` in GHC >= 9.2
+
 # 0.4.7
 * Fix Plugin silently fails when normalizing <= in GHC 9.4+ [#50](https://github.com/clash-lang/ghc-typelits-extra/issues/50)
 

--- a/src-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
+++ b/src-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
@@ -32,8 +32,7 @@ import GHC.TcPluginM.Extra
 import GHC.Builtin.Names (eqPrimTyConKey, hasKey, getUnique)
 import GHC.Builtin.Types (promotedTrueDataCon, promotedFalseDataCon)
 import GHC.Builtin.Types (boolTy, naturalTy, cTupleDataCon, cTupleTyCon)
-import GHC.Builtin.Types.Literals (typeNatTyCons)
-import GHC.Builtin.Types.Literals (typeNatCmpTyCon)
+import GHC.Builtin.Types.Literals (typeNatDivTyCon, typeNatModTyCon, typeNatCmpTyCon)
 import GHC.Core.Coercion (mkUnivCo)
 import GHC.Core.DataCon (dataConWrapId)
 import GHC.Core.Predicate (EqRel (NomEq), Pred (EqPred, IrredPred), classifyPredType)
@@ -315,8 +314,8 @@ lookupExtraDefs = do
     md2 <- lookupModule typeErrModule basePackage
     ExtraDefs <$> look md "Max"
               <*> look md "Min"
-              <*> pure (typeNatTyCons !! 5)
-              <*> pure (typeNatTyCons !! 6)
+              <*> pure typeNatDivTyCon
+              <*> pure typeNatModTyCon
               <*> look md "FLog"
               <*> look md "CLog"
               <*> look md "Log"

--- a/src-pre-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
+++ b/src-pre-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
@@ -42,7 +42,7 @@ import GHC.Builtin.Types (boolTy, naturalTy)
 #else
 import GHC.Builtin.Types (typeNatKind)
 #endif
-import GHC.Builtin.Types.Literals (typeNatTyCons)
+import GHC.Builtin.Types.Literals (typeNatDivTyCon, typeNatModTyCon)
 #if MIN_VERSION_ghc(9,2,0)
 import GHC.Builtin.Types.Literals (typeNatCmpTyCon)
 #else
@@ -82,7 +82,7 @@ import TyCoRep    (Type (..))
 import TysWiredIn (typeNatKind, promotedTrueDataCon, promotedFalseDataCon)
 import TcTypeNats (typeNatLeqTyCon)
 #if MIN_VERSION_ghc(8,4,0)
-import TcTypeNats (typeNatTyCons)
+import TcTypeNats (typeNatDivTyCon, typeNatModTyCon)
 #else
 import TcPluginM  (zonkCt)
 #endif
@@ -313,8 +313,8 @@ lookupExtraDefs = do
     ExtraDefs <$> look md "Max"
               <*> look md "Min"
 #if MIN_VERSION_ghc(8,4,0)
-              <*> pure (typeNatTyCons !! 5)
-              <*> pure (typeNatTyCons !! 6)
+              <*> pure typeNatDivTyCon
+              <*> pure typeNatModTyCon
 #else
               <*> look md "Div"
               <*> look md "Mod"


### PR DESCRIPTION
While implementing reduction `Mod n p <= q` -> `p <= q + 1`  I noticed that the lookups for `Div` and `Mod` were wrong post GHC 9.2.

I have fixed that and also added the reduction. If you want I can split this up into two PRs. One for the lookup fix and one for the reduction. But since the each change is so small I didn't feel like the overhead is worth it.