### PR TITLE
Use TemplateHaskellQuotes for Name lookup

### DIFF
--- a/ghc-typelits-extra.cabal
+++ b/ghc-typelits-extra.cabal
@@ -84,6 +84,7 @@ library
     hs-source-dirs:    src-pre-ghc-9.4
   if impl(ghc >= 9.4) && impl(ghc < 9.10)
     hs-source-dirs:    src-ghc-9.4
+    build-depends:     template-haskell          >= 2.17    && <2.22
   default-language:    Haskell2010
   other-extensions:    DataKinds
                        FlexibleInstances


### PR DESCRIPTION
Adds support for GHC 9.10 by making name resolution less dependent upon the internal structure of `base`.