### PR TITLE
Add CLog with well-defined zero case

### DIFF
--- a/src-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
+++ b/src-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
@@ -327,6 +327,7 @@ lookupExtraDefs = do
               <*> look ''GHC.TypeLits.Extra.LCM
               <*> look ''Data.Type.Ord.OrdCond
               <*> look ''GHC.TypeError.Assert
+              <*> look ''GHC.TypeLits.Extra.CLogWZ
   where
     look nm = tcLookupTyCon =<< lookupTHName nm
 

--- a/src-pre-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
+++ b/src-pre-ghc-9.4/GHC/TypeLits/Extra/Solver.hs
@@ -331,6 +331,7 @@ lookupExtraDefs = do
               <*> pure typeNatLeqTyCon
               <*> pure typeNatLeqTyCon
 #endif
+              <*> look md "CLogWZ"
   where
     look md s = tcLookupTyCon =<< lookupName md (mkTcOcc s)
     myModule  = mkModuleName "GHC.TypeLits.Extra"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -234,6 +234,36 @@ test58b
   -> Proxy (Max (n+2) 1)
 test58b = test58a
 
+test59 :: Proxy (CLogWZ 3 10 9) -> Proxy 3
+test59 = id
+
+test60 :: Proxy ((CLogWZ 3 10 3) + x) -> Proxy (x + (CLogWZ 2 7 8))
+test60 = id
+
+test61 :: Proxy (CLogWZ x (x^y) 8) -> Proxy y
+test61 = id
+
+test62 :: Integer
+test62 = natVal (Proxy :: Proxy (CLogWZ 6 8 3))
+
+test63 :: Integer
+test63 = natVal (Proxy :: Proxy (CLogWZ 3 10 9))
+
+test64 :: Integer
+test64 = natVal (Proxy :: Proxy ((CLogWZ 2 4 11) * (3 ^ (CLogWZ 2 4 8))))
+
+test65 :: Integer
+test65 = natVal (Proxy :: Proxy (Max (CLogWZ 2 4 8) (CLogWZ 4 20 5)))
+
+test66 :: Proxy (CLogWZ 3 0 8) -> Proxy 8
+test66 = id
+
+test67 :: Proxy (CLogWZ 2 0 x) -> Proxy x
+test67 = id
+
+test68 :: Proxy (CLogWZ 5 0 0) -> Proxy 0
+test68 = id
+
 main :: IO ()
 main = defaultMain tests
 
@@ -410,6 +440,36 @@ tests = testGroup "ghc-typelits-natnormalise"
       "Proxy"
     , testCase "forall n p . n + 1 <= Max (n + p + 1) p" $
       show (test57 Proxy Proxy Proxy) @?=
+      "Proxy"
+    , testCase "CLogWZ 3 10 9 ~ 3" $
+      show (test59 Proxy) @?=
+      "Proxy"
+    , testCase "forall x . CLogWZ 3 10 3 + x ~ x + CLogWZ 2 7 8" $
+      show (test60 Proxy) @?=
+      "Proxy"
+    , testCase "forall x>1 . CLogWZ x (x^y) 8 ~ y" $
+      show (test61 Proxy) @?=
+      "Proxy"
+    , testCase "KnownNat (CLogWZ 6 8 3) ~ 2" $
+      show test62 @?=
+      "2"
+    , testCase "KnownNat (CLogWZ 3 10 9) ~ 3" $
+      show test63 @?=
+      "3"
+    , testCase "KnownNat ((CLogWZ 2 4 11) * (3 ^ (CLogWZ 2 4 8)))) ~ 18" $
+      show test64 @?=
+      "18"
+    , testCase "KnownNat (Max (CLogWZ 2 4 8) (CLogWZ 4 20 5)) ~ 3" $
+      show test65 @?=
+      "3"
+    , testCase "CLogWZ 3 0 8 ~ 8" $
+      show (test66 Proxy) @?=
+      "Proxy"
+    , testCase "forall x. CLogWZ 2 0 x ~ x" $
+      show (test67 Proxy) @?=
+      "Proxy"
+    , testCase "CLogWZ 5 0 0 ~ 0" $
+      show (test68 Proxy) @?=
       "Proxy"
     ]
   , testGroup "errors"


### PR DESCRIPTION
The PR adds the `CLogWZ` type family to the solver, which allows for a `CLog` definition with a well defined output for the case of  the second non-base argument being zero. In this case the third argument is returned instead. The type family can be useful in cases, where the zero case needs to defined, as for example in the `Index 0` case within `clash-prelude` (cf. [clash-compiler PR #2784](https://github.com/clash-lang/clash-compiler/pull/2784)).

### Reviewers Note
The currently used naming scheme might still be a bit adhoc, but I couldn't figure out any more elegant solution yet. One option might be to add total versions for all non-total type families of `ghc-typelits-extra` with extra parameters defining the return value in the undefined cases. In terms of naming we then just could add `Total` as a prefix / suffix to these versions, e.g., `TotalDiv` or `DivTotal`. In the particular case of `CLog` there are many undefined cases, however, which makes me unsure of how practical this approach would be.

---

### TODOs
  - [ ] This still is a draft PR, as I'd like to see [this fact](https://github.com/clash-lang/clash-compiler/pull/2784/files#diff-c5d06203ed828f905a88d010d96c98851be5ca4cee3abc46a05b3131f5161080R214) being covered here within the plugin as well.
  - [ ] Add the new type families to the readme and check the generated documentation.