### PR TITLE
Simpler divru

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-extra`](http://hackage.haskell.org/package/ghc-typelits-extra) package
 
+# Unreleased
+* Make definition of `DivRU` player nicer GHC.typelits.natnormalise.
+
 # 0.4.7 *May 22nd, 2024*
 * Add support for GHC 9.10.1
 * Fix Plugin silently fails when normalizing <= in GHC 9.4+ [#50](https://github.com/clash-lang/ghc-typelits-extra/issues/50)

--- a/src/GHC/TypeLits/Extra.hs
+++ b/src/GHC/TypeLits/Extra.hs
@@ -141,7 +141,7 @@ instance (KnownNat x, KnownNat y, 1 <= y) => KnownNat2 $(nameToSymbol ''Div) x y
 #endif
 
 -- | A variant of 'Div' that rounds up instead of down
-type DivRU n d = Div (n + (d - 1)) d
+type DivRU n d = 1 + Div (n - 1) d
 
 #if !MIN_VERSION_ghc(8,4,0)
 -- | Type-level 'mod'

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -234,11 +234,18 @@ test58b
   -> Proxy (Max (n+2) 1)
 test58b = test58a
 
+test59
+  :: SNat n
+  -> SNat p
+  -> Proxy (1 <=? DivRU (n + 1) (p + 1))
+  -> Proxy True
+test59 SNat SNat = id
+
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "ghc-typelits-natnormalise"
+tests = testGroup "ghc-typelits-extra"
   [ testGroup "Basic functionality"
     [ testCase "GCD 6 8 ~ 2" $
       show (test1 Proxy) @?=


### PR DESCRIPTION
Write round up division as `1 + Div (n - 1) d` which makes it play much
nicer with natnormalise. Now you no longer need to manually prove `1 <= n, 1 <= d => 1 <= DivRU n d`. 