### PR TITLE
tests: Adding simple wildcard matcher

### DIFF
--- a/tests-ghc-9.4/ErrorTests.hs
+++ b/tests-ghc-9.4/ErrorTests.hs
@@ -189,13 +189,13 @@ testFail20Errors =
   ,"               with: CLog 3 10"]
 
 testFail21Errors =
-  ["Expected: Proxy (Min a (a * b)) -> Proxy a"
+  ["Expected: Proxy (Min a (a \\* b)) -> Proxy a"
   ,"  Actual: Proxy a -> Proxy a"
   ]
 
 testFail22Errors =
-  ["Expected: Proxy (Max a (a * b)) -> Proxy (a * b)"
-  ,"  Actual: Proxy (Max a (a * b)) -> Proxy (Max a (a * b))"]
+  ["Expected: Proxy (Max a (a \\* b)) -> Proxy (a \\* b)"
+  ,"  Actual: Proxy (Max a (a \\* b)) -> Proxy (Max a (a \\* b))"]
 
 testFail27Errors =
   ["Expected: Proxy ((n + 2) <=? Max (n + 1) 1) -> Proxy 'True"
@@ -212,26 +212,15 @@ testFail23Errors =
   ["Couldn't match type ‘'True’ with ‘'False’"]
 
 testFail24Errors =
-#if __GLASGOW_HASKELL__ >= 910
-  ["Couldn't match type ‘ghc-internal-9.1001.0:GHC.Internal.Data.Type.Ord.OrdCond"
+  ["Couldn't match type ‘*Data.Type.Ord.OrdCond"
   ,"(CmpNat z (Max x y)) 'True 'True 'False’"
   ,"with ‘'True’"]
-#else
-  ["Couldn't match type ‘Data.Type.Ord.OrdCond"
-  ,"(CmpNat z (Max x y)) 'True 'True 'False’"
-  ,"with ‘'True’"]
-#endif
 
 testFail25Errors =
-#if __GLASGOW_HASKELL__ >= 910
-  ["Couldn't match type ‘ghc-internal-9.1001.0:GHC.Internal.Data.Type.Ord.OrdCond"
+  ["Couldn't match type ‘*Data.Type.Ord.OrdCond"
   ,"(CmpNat (x + 1) (Max x y)) 'True 'True 'False’"
   ,"with ‘'True’"]
-#else
-  ["Couldn't match type ‘Data.Type.Ord.OrdCond"
-  ,"(CmpNat (x + 1) (Max x y)) 'True 'True 'False’"
-  ,"with ‘'True’"]
-#endif
+
 
 testFail26Errors =
 #if __GLASGOW_HASKELL__ >= 906

--- a/tests-pre-ghc-9.4/ErrorTests.hs
+++ b/tests-pre-ghc-9.4/ErrorTests.hs
@@ -190,13 +190,13 @@ testFail20Errors =
   ,"               with: CLog 3 10"]
 
 testFail21Errors =
-  ["Expected: Proxy (Min a (a * b)) -> Proxy a"
+  ["Expected: Proxy (Min a (a \\* b)) -> Proxy a"
   ,"  Actual: Proxy a -> Proxy a"
   ]
 
 testFail22Errors =
-  ["Expected: Proxy (Max a (a * b)) -> Proxy (a * b)"
-  ,"  Actual: Proxy (Max a (a * b)) -> Proxy (Max a (a * b))"]
+  ["Expected: Proxy (Max a (a \\* b)) -> Proxy (a \\* b)"
+  ,"  Actual: Proxy (Max a (a \\* b)) -> Proxy (Max a (a \\* b))"]
 
 testFail27Errors =
   ["Expected: Proxy ((n + 2) <=? Max (n + 1) 1) -> Proxy 'True"


### PR DESCRIPTION
With GHC 9.10.x it contains the minor version in the `<=` constraints when reporting errors. There is no CPP define for the minor version so a straightforward CPP check doesn't work. I added a simple wildcard character support to the error strings to handle this.