### PR TITLE
Fix wrong reification from `CLogWZ` to `CLog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-extra`](http://hackage.haskell.org/package/ghc-typelits-extra) package
 
+# Unreleased
+* Fix wrong reification from `CLogWZ` to `CLog` causing GHC panic. [#71](https://github.com/clash-lang/ghc-typelits-extra/issues/71)
+
 # 0.5.2 *December 3rd 2025*
 * Add `CLogWZ`, an extension of 'CLog', which returns the additional third argument in case the second argument is zero
 * Add rewrite rules for `Min`, `Max`, `FLog`, `CLog`, and `Log`

--- a/src/GHC/TypeLits/Extra/Solver/Operations.hs
+++ b/src/GHC/TypeLits/Extra/Solver/Operations.hs
@@ -119,7 +119,7 @@ reifyEOP defs = \case
   Div x y      -> mkTyConApp (divTyCon defs)  $ reifyEOP defs <$> [x, y]
   Mod x y      -> mkTyConApp (modTyCon defs)  $ reifyEOP defs <$> [x, y]
   CLog x y     -> mkTyConApp (clogTyCon defs) $ reifyEOP defs <$> [x, y]
-  CLogWZ x y z -> mkTyConApp (clogTyCon defs) $ reifyEOP defs <$> [x, y, z]
+  CLogWZ x y z -> mkTyConApp (clogWZTyCon defs) $ reifyEOP defs <$> [x, y, z]
   FLog x y     -> mkTyConApp (flogTyCon defs) $ reifyEOP defs <$> [x, y]
   Log x y      -> mkTyConApp (logTyCon defs)  $ reifyEOP defs <$> [x, y]
   GCD x y      -> mkTyConApp (gcdTyCon defs)  $ reifyEOP defs <$> [x, y]

--- a/tests/ShouldError.hs
+++ b/tests/ShouldError.hs
@@ -38,6 +38,7 @@ tests = testGroup "ShouldError"
     , test25
     , test26
     , test27
+    , test28
     ]
 
 preamble :: String
@@ -548,3 +549,26 @@ expected27 =
 
 test27 :: TestTree
 test27 = testCase "n + 2 <=? Max (n + 1) 1 /~ True" $ assertCompileError source27 expected27
+
+source28 :: String
+source28 = [i|
+{-# LANGUAGE KindSignatures #-}
+|] <> preamble <> [i|
+type Size (n :: Nat) = Max 0 (CLogWZ 2 n 0)
+
+pack :: Proxy n -> Proxy (Size n)
+pack _ = Proxy
+
+repro :: Proxy (Size 1)
+repro = pack (undefined :: Proxy (n :: Nat))
+|]
+
+expected28 :: [String]
+expected28 =
+  ["CLogWZ 2 n"
+  ,"ambiguous"
+  ]
+
+test28 :: TestTree
+test28 = testCase "CLogWZ reify with Max 0 (type synonym) doesn't panic" $
+  assertCompileError source28 expected28


### PR DESCRIPTION
causing GHC panic. [#71](https://github.com/clash-lang/ghc-typelits-extra/issues/71)